### PR TITLE
New Feature: NTRIP client (WiFi)

### DIFF
--- a/software/CONFIG.h
+++ b/software/CONFIG.h
@@ -32,6 +32,8 @@ const char THINGSTREAM_ZTPURL[]         = "https://" THINGSTREAM_SERVER THINGSTR
 #define    AWSTRUST_ROOTCAPATH            "/repository/AmazonRootCA1.pem"
 const char AWSTRUST_ROOTCAURL[]         = "https://" AWSTRUST_SERVER AWSTRUST_ROOTCAPATH;
 
+const unsigned short NTRIP_SERVER_PORT  = 2101;
+
 const unsigned short MQTT_BROKER_PORT   = 8883; 
 const int MQTT_MAX_MSG_SIZE             = 9*1024;
 
@@ -87,7 +89,12 @@ const char CONFIG_VALUE_MNOPROF[]       = "mnoProfile";
 const char CONFIG_VALUE_REGION[]        = "region";          
 const char CONFIG_VALUE_FREQ[]          = "freq";
 const char CONFIG_VALUE_KEY[]           = "ppKey";
-                  
+
+const char CONFIG_VALUE_NTRIP_SERVER[]  = "ntripServer";
+const char CONFIG_VALUE_NTRIP_MOUNTPT[] = "ntripMountpoint";
+const char CONFIG_VALUE_NTRIP_USERNAME[]= "ntripUsername";
+const char CONFIG_VALUE_NTRIP_PASSWORD[]= "ntripPassword";
+                      
 class CONFIG {
 public:
 

--- a/software/GNSS.h
+++ b/software/GNSS.h
@@ -264,7 +264,7 @@ public:
             fixLut[fixType & 7], carrLut[carrSoln & 3], 1e-3*ubxDataStruct->hAcc, fLat, fLon, 1e-3 * ubxDataStruct->hMSL);
       Websocket.write(string, len);
 #endif
-#if 1
+#if 0
       char chLat = (fLat < 0) ? 'W' : 'E';
       if (fLat < 0) fLat = -fLat;
       int iLat = (int)(fLat)

--- a/software/GNSS.h
+++ b/software/GNSS.h
@@ -264,6 +264,27 @@ public:
             fixLut[fixType & 7], carrLut[carrSoln & 3], 1e-3*ubxDataStruct->hAcc, fLat, fLon, 1e-3 * ubxDataStruct->hMSL);
       Websocket.write(string, len);
 #endif
+#if 1
+      char chLat = (fLat < 0) ? 'W' : 'E';
+      if (fLat < 0) fLat = -fLat;
+      int iLat = (int)(fLat)
+      fLat *= 60.0;
+      fLat = (fLat - iLat) * 60.0;
+      char chLon = (fLon < 0) ? 'S' : 'N';
+      if (fLon < 0) fLon = -fLon;
+      int iLon = (int)(fLat)
+      fLon *= 60.0;
+      fLon = (fLon - iLon) * 60.0;
+      //                        "$GPGGA,HHMMSS.ss,DDmm.mmm,N/S,DDmm.mmm,E/W,q,sat,dop,alt,M,und,M,age,dgps"
+      //                        "$GPGGA,134658.00,5106.9792,N,11402.3003,W,1,12,1.0,1048.47,M,,M,,*60"
+      len = snprintf(string, sizeof(string), "$GPGGA,%02d:%02d:%02d.00,%02d%7.4f,%c,%02d%7.4f,%c,%c,10,%.1f,%.2f,M,,M,,*",
+            ubxDataStruct->hour, ubxDataStruct->min,ubxDataStruct->sec, iLat, fLat, iLon, fLon, 
+            ((fixType != 0) && (ubxDataStruct->flags.bits.gnssFixOK)) ? '1' : '0', ubxDataStruct->nSAT, ubxDataStruct->pDOP, ubxDataStruct->hMSL);
+      char crc = 0;
+      for (int i = 1; i < len-1, i ++);
+        crc ^= string[i];
+      sprintf(&string[len], "%02D\r\n", crc);
+#endif
     }
   }
   

--- a/software/LTE.h
+++ b/software/LTE.h
@@ -27,7 +27,7 @@ extern class LTE Lte;
 
 const int LTE_DETECT_RETRY        =  5000;
 const int LTE_WAITREGISTER_RETRY  =  1000;
-const int LTE_CHECKSIM_RETRY      =  5000;
+const int LTE_CHECKSIM_RETRY      = 60000;
 const int LTE_ACTIVATION_RETRY    = 10000;
 const int LTE_HTTPZTP_RETRY       = 60000;
 const int LTE_MQTTCONNECT_RETRY   = 10000;

--- a/software/WLAN.h
+++ b/software/WLAN.h
@@ -161,7 +161,7 @@ public:
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_LTEAPN, "APN", Config.getValue(CONFIG_VALUE_LTEAPN).c_str(), 64);
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_SIMPIN, "SIM pin", Config.getValue(CONFIG_VALUE_SIMPIN).c_str(), 8, " type=\"password\"");
     new (&parameters[p++]) WiFiManagerParameter("<p style=\"font-weight:Bold;\">NTRIP configuration</p>");
-    new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_SERVER, "Server", Config.getValue(CONFIG_VALUE_NTRIP_SERVER).c_str(), 64);
+    new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_SERVER, "Server:Port", Config.getValue(CONFIG_VALUE_NTRIP_SERVER).c_str(), 64");
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_MOUNTPT, "Mount point", Config.getValue(CONFIG_VALUE_NTRIP_MOUNTPT).c_str(), 64);  
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_USERNAME, "Username", Config.getValue(CONFIG_VALUE_NTRIP_USERNAME).c_str(), 64);
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_PASSWORD, "Password", Config.getValue(CONFIG_VALUE_NTRIP_PASSWORD).c_str(), 64, " type=\"password\"");
@@ -350,12 +350,15 @@ public:
             setState(ONLINE);
           } else {
             ttagNextTry = now + WIFI_NTRIP_RETRY;
-            Log.info("WLAN NTRIP connecting to \"%s\":%d", ntrip.c_str(), NTRIP_SERVER_PORT);
-            int ok = ntripWifiClient.connect(ntrip.c_str(), NTRIP_SERVER_PORT);
+            int pos = ntrip.indexOf(':');
+            String server = (-1 == pos) ? ntrip : ntrip.substring(0,pos);
+            uint16_t port = (-1 == pos) ? NTRIP_SERVER_PORT : ntrip.substring(pos+1).toInt();
+            Log.info("WLAN NTRIP connecting to \"%s:%d\"", server.c_str(), port);
+            int ok = ntripWifiClient.connect(server.c_str(), port);
             if (!ok) {
-              Log.error("WLAN NTRIP connect to \"%s\":%d failed with error", ntrip.c_str(), NTRIP_SERVER_PORT);
+              Log.error("WLAN NTRIP connect to \"%s:%d\" failed with error", server.c_str(), port);
             } else {
-              Log.info("WLAN NTRIP connected to \"%s\":%d", ntrip.c_str(), NTRIP_SERVER_PORT);
+              Log.info("WLAN NTRIP connected to \"%s:%d", server.c_str(), port);
               String mntpnt = Config.getValue(CONFIG_VALUE_NTRIP_MOUNTPT);
               String user = Config.getValue(CONFIG_VALUE_NTRIP_USERNAME);
               String pwd = Config.getValue(CONFIG_VALUE_NTRIP_PASSWORD);

--- a/software/WLAN.h
+++ b/software/WLAN.h
@@ -161,7 +161,7 @@ public:
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_LTEAPN, "APN", Config.getValue(CONFIG_VALUE_LTEAPN).c_str(), 64);
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_SIMPIN, "SIM pin", Config.getValue(CONFIG_VALUE_SIMPIN).c_str(), 8, " type=\"password\"");
     new (&parameters[p++]) WiFiManagerParameter("<p style=\"font-weight:Bold;\">NTRIP configuration</p>");
-    new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_SERVER, "Server:Port", Config.getValue(CONFIG_VALUE_NTRIP_SERVER).c_str(), 64");
+    new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_SERVER, "Server:Port", Config.getValue(CONFIG_VALUE_NTRIP_SERVER).c_str(), 64);
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_MOUNTPT, "Mount point", Config.getValue(CONFIG_VALUE_NTRIP_MOUNTPT).c_str(), 64);  
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_USERNAME, "Username", Config.getValue(CONFIG_VALUE_NTRIP_USERNAME).c_str(), 64);
     new (&parameters[p++]) WiFiManagerParameter(CONFIG_VALUE_NTRIP_PASSWORD, "Password", Config.getValue(CONFIG_VALUE_NTRIP_PASSWORD).c_str(), 64, " type=\"password\"");
@@ -396,9 +396,6 @@ public:
               }
               ok = (expectedReply[len] == 0) && ok;
               if (ok) { 
-                //                                UTC       lat          lon          qi
-                // ntripWifiClient.printf("$GPGGA,HHMMSS.ss,DDmm.mmm,N/S,DDmm.mmm,E/W,q,sat,dop,alt,M,und,M,age,dgps")
-                //                        "$GPGGA,134658.00,5106.9792,N,11402.3003,W,1,12,1.0,1048.47,M,,M,,*60"
                 Log.info("WLAN NTRIP got expected reply \"%s\"", expectedReply);
                 setState(NTRIP_CONNECTED);
               }


### PR DESCRIPTION
The main feature of this pull request is the addition of **NTRIP client using WiFi**. To use you need to set the PointPerfect Correction source to none. Client sends NMEA GGA every 20s. 

Other improvements are: 
- Wait for DNS to respond before tying to provision or connect
- Collect garbage when changing the config, avoids memory issues in its json